### PR TITLE
Fix DialogResult error when cancelling Twitch connection without Client ID

### DIFF
--- a/src/EZStreamer/Views/TwitchAuthWindow.xaml.cs
+++ b/src/EZStreamer/Views/TwitchAuthWindow.xaml.cs
@@ -24,6 +24,14 @@ namespace EZStreamer.Views
             
             LoadingPanel.Visibility = Visibility.Visible;
             
+            // Defer client ID check until after window is shown
+            this.Loaded += TwitchAuthWindow_Loaded;
+        }
+
+        private void TwitchAuthWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            this.Loaded -= TwitchAuthWindow_Loaded; // Unsubscribe
+            
             // Check if client ID is configured
             if (string.IsNullOrEmpty(_clientId))
             {


### PR DESCRIPTION
## Fix DialogResult Error When Cancelling Twitch Connection

This PR fixes the error that occurs when clicking "Connect Twitch" → "Cancel" (when no Twitch Client ID is configured):

```
"an unexpected error : dialogresult can be set only after window is created and shown as dialog"
```

### Root Cause
The error occurred in `TwitchAuthWindow.xaml.cs` because the constructor was calling `ShowConfigurationNeeded()` when the client ID was not configured, which tried to set `DialogResult = false` and close the window before it had been properly shown as a dialog via `ShowDialog()`.

### Solution
- **Moved the client ID check from the constructor to the `Loaded` event handler**
- This ensures the window is properly initialized and shown as a dialog before any attempt to set `DialogResult`
- Added proper event handler cleanup to prevent memory leaks

### Changes Made
1. **Constructor**: Removed immediate client ID check, added `Loaded` event subscription
2. **New `TwitchAuthWindow_Loaded` method**: Handles the deferred client ID check
3. **Proper cleanup**: Unsubscribes from the `Loaded` event after first execution

### Testing
- The dialog will now properly handle the case where no Twitch Client ID is configured
- Users can cancel the configuration dialog without causing an unhandled exception
- The authentication flow continues to work normally when a client ID is configured

Resolves #3